### PR TITLE
Read merchant Id from plist and set it

### DIFF
--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -412,6 +412,7 @@ RCT_EXPORT_METHOD(paymentRequestWithApplePay:(NSArray *)items
     NSMutableArray *shippingMethodsItems = options[@"shippingMethods"] ? options[@"shippingMethods"] : [NSMutableArray array];
     NSString* currencyCode = options[@"currencyCode"] ? options[@"currencyCode"] : @"USD";
     NSString* countryCode = options[@"countryCode"] ? options[@"countryCode"] : @"US";
+    NSString *merchantId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"APPLE_PAY_MERCHANT_ID"];
 
     NSMutableArray *shippingMethods = [NSMutableArray array];
 


### PR DESCRIPTION
## Description
The merchant Id needs to be read from the plist file, to play nice with our build systems
