### PR TITLE
Fix the null Error object

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -177,8 +177,7 @@ public class StripeModule extends ReactContextBaseJavaModule {
             promise.resolve(convertTokenToWritableMap(token));
           }
           public void onError(Exception error) {
-            error.printStackTrace();
-            promise.reject(toErrorCode(error), error.getMessage());
+            promise.reject(error);
           }
         });
     } catch (Exception e) {


### PR DESCRIPTION
## Problem
The Error object was null, and `toErrorCode` throws a nullPointerException. We don't use the error code anyway, so I removed it